### PR TITLE
synchronous-refresh

### DIFF
--- a/gui/widgets/buttons.py
+++ b/gui/widgets/buttons.py
@@ -55,7 +55,7 @@ class Button(Widget):
         h = self.height
         if not self.visible:  # erase the button
             display.usegrey(False)
-            display.fill_rect(x, y, w, h, BGCOLOR)
+            display.fill_rect(x, y, w, h, self.bgcolor)
             return
         super().show()  # Blank rectangle containing button
         if self.shape == CIRCLE:  # Button coords are of top left corner of bounding box


### PR DESCRIPTION
I made tests with enabling synchronous update mode for screen. This can be turned on with Screen.sync_update = True per Screen subclass.

This feature hooks into Widget class draw, which is changed into property and setting draw=True will also trigget screen refresh with Screen.rfsh_start.set()
Currently code includes test printouts and refreshing is tested only with Button class. 

Do you think this would be good way to save resources and take screen refresh to control?
